### PR TITLE
Fix tag saving in wizard

### DIFF
--- a/wizard/steps/step3_tags.py
+++ b/wizard/steps/step3_tags.py
@@ -26,7 +26,8 @@ def handle(bot, m, w):
         bot.send_message(user_id, "Wizard canceled.", reply_markup=types.ReplyKeyboardRemove())
         return
 
-    # 3) Otherwise, store the chosen tag
+    # 3) Otherwise, store the chosen tag. Only a single tag is supported
+    # so we save it under the ``tag`` key as plain text.
     w["tag"] = m.text
 
     # 4) Advance to step 4, ask for location via map or text

--- a/wizard/steps/step5_visibility.py
+++ b/wizard/steps/step5_visibility.py
@@ -60,7 +60,8 @@ def handle(bot, m, w):
             longitude=w.get("longitude", None),
             address=w.get("address", None),
             visibility=w["visibility"],
-            tags=",".join(w.get("tags", []))
+            # Only one tag is supported. It was saved under ``tag`` in step 3.
+            tags=w.get("tag", "")
         )        
         db.add(ev)
         db.commit()


### PR DESCRIPTION
## Summary
- ensure step3 stores the selected tag under `tag` (single string)
- adjust step5 to use the single `tag` field when persisting the event

## Testing
- `python -m py_compile *.py wizard/*.py wizard/steps/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6841aba6dc148332b998b74a844789fa