### PR TITLE
Fix event submenu buttons

### DIFF
--- a/menus/events_menu.py
+++ b/menus/events_menu.py
@@ -7,10 +7,10 @@ from ..helpers import cb
 from .state import set_state, get_state
 
 EVENTS_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-EVENTS_KB.add("\ud83d\udccb My events", "\ud83e\udefc Friends events", "\ud83c\udf10 Public events", "\u2b05\ufe0f Back")
+EVENTS_KB.add("📋 My events", "👥 Friends events", "🌐 Public events", "⬅️ Back")
 
 LIST_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-LIST_KB.add("\ud83d\udccd Show on map", "\u2b05\ufe0f Back")
+LIST_KB.add("📍 Show on map", "⬅️ Back")
 
 
 def _list_events(user_id, events):
@@ -41,7 +41,7 @@ def register(bot):
         bot.send_message(msg.chat.id, text, reply_markup=ikb)
         bot.send_message(msg.chat.id, "Select:", reply_markup=EVENTS_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "\ud83d\udccb My events")
+    @bot.message_handler(func=lambda m: m.text == "📋 My events")
     def my_events(msg):
         print("my events handling")
         uid = msg.from_user.id
@@ -57,7 +57,7 @@ def register(bot):
         bot.send_message(msg.chat.id, "<b>Joined:</b>\n" + text_j, parse_mode="HTML", reply_markup=kb_j)
         bot.send_message(msg.chat.id, "Options:", reply_markup=LIST_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "\ud83e\udefc Friends events")
+    @bot.message_handler(func=lambda m: m.text == "👥 Friends events")
     def friends_events(msg):
         uid = msg.from_user.id
         set_state(uid, "friends_events")
@@ -66,7 +66,7 @@ def register(bot):
         bot.send_message(msg.chat.id, text, reply_markup=ikb)
         bot.send_message(msg.chat.id, "Options:", reply_markup=LIST_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "\ud83c\udf10 Public events")
+    @bot.message_handler(func=lambda m: m.text == "🌐 Public events")
     def public_events(msg):
         uid = msg.from_user.id
         set_state(uid, "public_events")
@@ -76,11 +76,11 @@ def register(bot):
         bot.send_message(msg.chat.id, text, reply_markup=ikb)
         bot.send_message(msg.chat.id, "Options:", reply_markup=LIST_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "\ud83d\udccd Show on map")
+    @bot.message_handler(func=lambda m: m.text == "📍 Show on map")
     def show_on_map(msg):
         bot.reply_to(msg, "Map view is not implemented yet.")
 
-    @bot.message_handler(func=lambda m: m.text == "\u2b05\ufe0f Back")
+    @bot.message_handler(func=lambda m: m.text == "⬅️ Back")
     def back(msg):
         uid = msg.from_user.id
         state = get_state(uid)

--- a/menus/friends_menu.py
+++ b/menus/friends_menu.py
@@ -2,11 +2,11 @@ from telebot import types
 from .state import set_state
 
 BACK_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
-BACK_KB.add("\u2b05\ufe0f Back")
+BACK_KB.add("⬅️ Back")
 
 
 def register(bot):
-    @bot.message_handler(func=lambda m: m.text == "\ud83d\udc65 Friends")
+    @bot.message_handler(func=lambda m: m.text == "👥 Friends")
     def friends_menu(msg):
         set_state(msg.from_user.id, "friends")
         bot.send_message(msg.chat.id, "Friends functionality coming soon.", reply_markup=BACK_KB)

--- a/menus/settings_menu.py
+++ b/menus/settings_menu.py
@@ -4,16 +4,16 @@ from ..models import Event, Participation
 from .state import set_state, get_state
 
 SETTINGS_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
-SETTINGS_KB.add("\ud83d\uddff Delete events", "\u2b05\ufe0f Back")
+SETTINGS_KB.add("🗑 Delete events", "⬅️ Back")
 
 
 def register(bot):
-    @bot.message_handler(func=lambda m: m.text == "\u2699\ufe0f Settings")
+    @bot.message_handler(func=lambda m: m.text == "⚙️ Settings")
     def settings_menu(msg):
         set_state(msg.from_user.id, "settings")
         bot.send_message(msg.chat.id, "Settings:", reply_markup=SETTINGS_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "\ud83d\uddff Delete events")
+    @bot.message_handler(func=lambda m: m.text == "🗑 Delete events")
     def delete_events(msg):
         with SessionLocal() as db:
             db.query(Participation).delete()
@@ -21,7 +21,7 @@ def register(bot):
             db.commit()
         bot.reply_to(msg, "All events have been deleted.")
 
-    @bot.message_handler(func=lambda m: m.text == "\u2b05\ufe0f Back" and get_state(m.from_user.id) == "settings")
+    @bot.message_handler(func=lambda m: m.text == "⬅️ Back" and get_state(m.from_user.id) == "settings")
     def back(msg):
         from ..bot import MAIN_KB
         set_state(msg.from_user.id, "main")


### PR DESCRIPTION
## Summary
- use proper emoji characters in reply keyboards and handlers
- update friends and settings menus to use the same format

## Testing
- `python3 -m compileall -q . && echo OK`
- `python3 -m bot` *(fails: ModuleNotFoundError: No module named 'telebot')*

------
https://chatgpt.com/codex/tasks/task_e_6842ee4874608332af5113ebe3af99ba