### PR TITLE
Add admin chat ID env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,14 @@ Build a lightweight web service that lets people **share upcoming-event plans**,
 
 ---
 
+## Configuration
+
+Set the following environment variables before running the bot:
+
+- `BOT_TOKEN` — Telegram bot token (required)
+- `DB_URL` — SQLAlchemy database URL (optional, defaults to `sqlite:///db.sqlite3`)
+- `ADMIN_CHAT_ID` — chat ID to notify on startup (optional)
+
+---
+
 ## 2 — Development Roadmap

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@
 import logging
 from telebot import TeleBot, types
 from .callbacks import register_callbacks
-from .config import BOT_TOKEN
+from .config import BOT_TOKEN, ADMIN_CHAT_ID
 from .database import Base, engine
 from .menus import register_menu
 # from .wizard_handlers import register_wizard
@@ -35,10 +35,11 @@ register_start(bot)
 register_dispatcher(bot)
 register_callbacks(bot)
 
-try:
-    bot.send_message("@andrey-manakov", "Bot started")
-except Exception as e:
-    log.warning("Failed to notify startup: %s", e)
+if ADMIN_CHAT_ID:
+    try:
+        bot.send_message(ADMIN_CHAT_ID, "Bot started")
+    except Exception as e:
+        log.warning("Failed to notify startup: %s", e)
 
 def main():
     log.info("Polling...")

--- a/config.py
+++ b/config.py
@@ -10,5 +10,6 @@ for p in (pathlib.Path(__file__).resolve().parents[1]/".env",
 
 BOT_TOKEN=os.getenv("BOT_TOKEN")
 DB_URL=os.getenv("DB_URL","sqlite:///db.sqlite3")
+ADMIN_CHAT_ID=os.getenv("ADMIN_CHAT_ID")
 if not BOT_TOKEN:
     raise RuntimeError("BOT_TOKEN missing")


### PR DESCRIPTION
## Summary
- allow configuring a startup notification recipient
- optionally send bot startup message using `ADMIN_CHAT_ID`
- document environment variables in README

## Testing
- `python -m py_compile bot.py config.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684333db5bb4833281ff5a6dfbe283f6