### PR TITLE
Add restart service to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,3 +23,7 @@ jobs:
     - name: Deploy via SCP
       run: |
         scp -r ./* ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:${{ secrets.VPS_TARGET_DIR }}
+
+    - name: Restart invevent service
+      run: |
+        ssh ${{ secrets.VPS_ROOT }}@${{ secrets.VPS_HOST }} "systemctl restart invevent.service"


### PR DESCRIPTION
## Summary
- restart `invevent.service` on the VPS using root privileges

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684344617c908332aafa290e243b50f9