### PR TITLE
Fix missing dependency for map feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ python -m invevent.bot
 
 - **Event creation wizard** — step-by-step prompts to create a new event.
 - **Menus** to manage events, friends and settings.
+- **Show events on a map** — view locations of upcoming events as pins.
 
 1. Install Python 3.11 or later.
 2. Install the dependencies:
    ```bash
    pip install -r requirements.txt
    ```
+   The map feature relies on the `staticmap` package which is included in the
+   requirements file.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyTelegramBotAPI
 SQLAlchemy
 python-dotenv
+staticmap


### PR DESCRIPTION
## Summary
- add `staticmap` package to requirements
- document map feature and dependency in README

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68434ef096548332b39373b23cec8d16