### PR TITLE
Enable logging to file

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,12 @@ from .menus import register_menu
 from .wizard.wizard_start import register_start
 from .wizard.wizard_dispatcher import register_dispatcher
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    filename="bot.log",
+    filemode="a",
+)
 log=logging.getLogger("invevent")
 
 bot=TeleBot(BOT_TOKEN,parse_mode="HTML")


### PR DESCRIPTION
## Summary
- configure bot logging to append messages to `bot.log`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843503796e08332a34b9454206bc51c