### PR TITLE
Add interactive map using folium

### DIFF
--- a/menus/events_menu.py
+++ b/menus/events_menu.py
@@ -125,8 +125,8 @@ def register(bot):
             bot.reply_to(msg, "Please select a list first.")
             return
 
-        from ..map_view import show_events_on_map
-        show_events_on_map(bot, msg.chat.id, events)
+        from ..map_view import show_events_interactive_map
+        show_events_interactive_map(bot, msg.chat.id, events)
 
     @bot.message_handler(func=lambda m: m.text == "⬅️ Back")
     def back(msg):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ SQLAlchemy
 python-dotenv
 staticmap
 requests
+folium


### PR DESCRIPTION
## Summary
- allow viewing events on an interactive map
- generate an HTML map with clickable markers for each event
- update event menu to use the new interactive map
- include folium in dependencies

## Testing
- `python -m py_compile map_view.py menus/events_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_684367c9e3248332bbf7b8a5b134f8d2