### PR TITLE
Add demo data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ InvEvent is a small Telegram bot for planning outings with friends. It stores ev
 - **Deep links** for viewing an event description or joining it.
 - **Event lists** – browse your events, friends' private events and all public events.
 - **Map display** – show upcoming events on a single static map (uses OpenStreetMap for geocoding addresses).
-- **Simple settings** – delete all events for testing.
+- **Simple settings** – delete all events or generate sample data for testing.
 
 ## Configuration
 

--- a/demo_data.py
+++ b/demo_data.py
@@ -1,0 +1,58 @@
+import random
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from .database import SessionLocal
+from .models import User, Event, Friendship, EventVisibility
+from .wizard.wizard_utils import TOPICS, EVENT_OPTIONS
+
+# Cities list with bias towards Moscow
+CITIES = [
+    "Moscow", "Moscow", "Moscow", "Moscow", "Moscow",  # heavier weight
+    "Saint Petersburg", "Novosibirsk", "Yekaterinburg", "Kazan",
+    "Nizhny Novgorod", "Samara", "Omsk", "Chelyabinsk", "Rostov-on-Don"
+]
+
+
+def generate_test_data(user_id: int) -> None:
+    """Populate database with fake friends and events for `user_id`."""
+    with SessionLocal() as db:
+        # ensure user exists
+        if not db.get(User, user_id):
+            db.add(User(id=user_id, first_name=f"User{user_id}", username=None))
+            db.commit()
+
+        for i in range(10):
+            # unique friend id
+            while True:
+                fid = random.randint(10_000_000, 99_999_999)
+                if fid != user_id and db.get(User, fid) is None:
+                    break
+            db.add(User(id=fid, first_name=f"Friend{i+1}", username=f"friend{i+1}"))
+
+            relation = random.choice(["mutual", "user_to_friend", "friend_to_user"])
+            if relation in ("mutual", "user_to_friend"):
+                db.add(Friendship(follower_id=user_id, followee_id=fid))
+            if relation in ("mutual", "friend_to_user"):
+                db.add(Friendship(follower_id=fid, followee_id=user_id))
+
+            for _ in range(random.randint(3, 10)):
+                topic = random.choice(TOPICS)
+                title_opts = EVENT_OPTIONS.get(topic, ["other"])
+                title = random.choice(title_opts)
+                dt = datetime.now(timezone.utc) + timedelta(days=random.randint(0, 30))
+                city = random.choice(CITIES)
+                vis = random.choice(list(EventVisibility))
+                ev = Event(
+                    id=str(uuid.uuid4()),
+                    owner_id=fid,
+                    title=title,
+                    description="test event",
+                    datetime_utc=dt,
+                    location_txt=city,
+                    visibility=vis,
+                    tags=topic,
+                )
+                db.add(ev)
+
+        db.commit()

--- a/menus/settings_menu.py
+++ b/menus/settings_menu.py
@@ -2,9 +2,10 @@ from telebot import types
 from ..database import SessionLocal
 from ..models import Event, Participation
 from .state import set_state, get_state
+from ..demo_data import generate_test_data
 
 SETTINGS_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
-SETTINGS_KB.add("🗑 Delete events", "⬅️ Back")
+SETTINGS_KB.add("🗑 Delete events", "🧪 Generate test data", "⬅️ Back")
 
 
 def register(bot):
@@ -20,6 +21,11 @@ def register(bot):
             db.query(Event).delete()
             db.commit()
         bot.reply_to(msg, "All events have been deleted.")
+
+    @bot.message_handler(func=lambda m: m.text == "🧪 Generate test data")
+    def gen_test_data(msg):
+        generate_test_data(msg.from_user.id)
+        bot.reply_to(msg, "Test data generated.")
 
     @bot.message_handler(func=lambda m: m.text == "⬅️ Back" and get_state(m.from_user.id) == "settings")
     def back(msg):


### PR DESCRIPTION
## Summary
- add feature to generate sample friends and events
- expose new button in settings menu
- mention sample data generation in README

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448644bb148332b0cb5820c52a616f