### PR TITLE
Make first wizard buttons two-column

### DIFF
--- a/wizard/steps/step0_topic.py
+++ b/wizard/steps/step0_topic.py
@@ -10,8 +10,7 @@ def handle(bot, m, w):
 
     if m.text not in TOPICS:
         kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-        for t in TOPICS:
-            kb.add(t)
+        kb.add(*TOPICS)
         kb.add("cancel")
         bot.send_message(user_id, "Select a topic:", reply_markup=kb)
         return
@@ -20,7 +19,6 @@ def handle(bot, m, w):
     w["step"] = 1
 
     kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-    for opt in EVENT_OPTIONS.get(m.text, []):
-        kb.add(opt)
+    kb.add(*EVENT_OPTIONS.get(m.text, []))
     kb.add("back", "cancel")
     bot.send_message(user_id, "Select event type:", reply_markup=kb)

--- a/wizard/wizard_start.py
+++ b/wizard/wizard_start.py
@@ -16,8 +16,7 @@ def register_start(bot):
 
         # Keyboard for step 0: list of topics + cancel
         kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-        for t in TOPICS:
-            kb.add(t)
+        kb.add(*TOPICS)
         kb.add("cancel")
 
         bot.reply_to(m, "Select a topic:", reply_markup=kb)


### PR DESCRIPTION
## Summary
- display topic choices in two columns when starting the event wizard
- display event type options in two columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684490e8e4f883329707fb861b58edea