### PR TITLE
Modify settings to clean all data

### DIFF
--- a/menus/settings_menu.py
+++ b/menus/settings_menu.py
@@ -1,11 +1,11 @@
 from telebot import types
 from ..database import SessionLocal
-from ..models import Event, Participation
+from ..models import Event, Participation, Friendship, User
 from .state import set_state, get_state
 from ..demo_data import generate_test_data
 
 SETTINGS_KB = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
-SETTINGS_KB.add("🗑 Delete events", "🧪 Generate test data", "⬅️ Back")
+SETTINGS_KB.add("🗑 Clean the data", "🧪 Generate test data", "⬅️ Back")
 
 
 def register(bot):
@@ -14,13 +14,15 @@ def register(bot):
         set_state(msg.from_user.id, "settings")
         bot.send_message(msg.chat.id, "Settings:", reply_markup=SETTINGS_KB)
 
-    @bot.message_handler(func=lambda m: m.text == "🗑 Delete events")
-    def delete_events(msg):
+    @bot.message_handler(func=lambda m: m.text == "🗑 Clean the data")
+    def clean_data(msg):
         with SessionLocal() as db:
             db.query(Participation).delete()
             db.query(Event).delete()
+            db.query(Friendship).delete()
+            db.query(User).delete()
             db.commit()
-        bot.reply_to(msg, "All events have been deleted.")
+        bot.reply_to(msg, "All data have been deleted.")
 
     @bot.message_handler(func=lambda m: m.text == "🧪 Generate test data")
     def gen_test_data(msg):


### PR DESCRIPTION
## Summary
- update settings menu to show *Clean the data*
- new handler wipes all DB tables

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684493255e5c8332bac2a69bb84b1250