### PR TITLE
Handle venue and photo content types

### DIFF
--- a/menus/events_menu.py
+++ b/menus/events_menu.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from telebot import types
+from telebot.handler_backends import ContinueHandling
 from sqlalchemy import select
 from ..database import SessionLocal
 from ..models import Event, Participation, EventState, EventVisibility, Friendship
@@ -144,7 +145,7 @@ def register(bot):
     def handle_nearby_location(msg):
         uid = msg.from_user.id
         if get_state(uid) != "nearby_wait":
-            return
+            return ContinueHandling()
 
         prev = NEARBY_CTX.pop(uid, None)
         set_state(uid, prev or "events")

--- a/menus/friends_menu.py
+++ b/menus/friends_menu.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from telebot import types
+from telebot.handler_backends import ContinueHandling
 from sqlalchemy import select, func
 
 from ..database import SessionLocal
@@ -193,7 +194,7 @@ def register(bot):
     @bot.message_handler(content_types=["location"])
     def nearby_location(msg):
         if get_state(msg.from_user.id) != "friend_nearby_wait":
-            return
+            return ContinueHandling()
         set_state(msg.from_user.id, "friend_events")
         ctx = USER_CTX.get(msg.from_user.id)
         if not ctx:

--- a/wizard/wizard_dispatcher.py
+++ b/wizard/wizard_dispatcher.py
@@ -27,7 +27,10 @@ def register_dispatcher(bot):
     Then it does a “cancel” check, and finally dispatches to the proper step.
     """
     # @bot.message_handler(func=lambda m: wiz_get(m.from_user.id) is not None)
-    @bot.message_handler(func=lambda m: wiz_get(m.from_user.id) is not None, content_types=['text', 'location'])
+    @bot.message_handler(
+        func=lambda m: wiz_get(m.from_user.id) is not None,
+        content_types=['text', 'location', 'venue', 'photo']
+    )
     def _wizard_steps(m):
         user_id = m.from_user.id
         w = wiz_get(user_id)


### PR DESCRIPTION
## Summary
- update events_menu and friends_menu to forward unrelated location messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68449eee32208332b098164cd25b5d90